### PR TITLE
Add support for Doctrine + smart defaults

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,11 +30,26 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('faker');
 
         $rootNode
+            ->beforeNormalization()
+                ->always(function($v) {
+                    if (isset($v['orm'])) {
+                        $v['orm'] = strtolower($v['orm']);
+                    }
+                    return $v;
+                })
+            ->end()
+            ->validate()
+                ->ifTrue(function($v) {
+                    return !in_array($v['orm'], array('doctrine', 'propel'));
+                })
+                ->thenInvalid('"orm" must be one of ("doctrine", "propel")')
+            ->end()
             ->children()
-                ->scalarNode('seed')->end()
-                ->scalarNode('populator')->end()
-                ->scalarNode('entity')->end()
-                ->scalarNode('locale')->end()
+                ->scalarNode('seed')->defaultValue(0)->end()
+                ->scalarNode('orm')->defaultValue('propel')->end()
+                ->scalarNode('populator')->defaultNull()->end()
+                ->scalarNode('entity')->defaultNull()->end()
+                ->scalarNode('locale')->defaultValue(\Faker\Factory::DEFAULT_LOCALE)->end()
                 ->arrayNode('entities')
                     ->useAttributeAsKey('name')
                     ->prototype('array')

--- a/README.md
+++ b/README.md
@@ -40,16 +40,22 @@ Register the bundle in `app/AppKernel.php`:
 ## Reference Configuration ##
 
 In order to use the `BazingaFakerBundle`, you have to configure it.
-Actually, you just need to configure entities you want to populate and in which quantity (default: 5).
+
+First of all if you use Doctrine and not Propel you must define it so that the bundle can reconfigure itself:
 
 ``` yaml
 # app/config/config*.yml
 
 faker:
-    seed:       1234
-    locale:     en_GB
-    populator:  \Your\Own\Populator
-    entity:     \Your\Own\EntityPopulator
+    orm: doctrine
+```
+
+Afterwards you just need to configure which entities you want to populate and in which quantity (default: 5).
+
+``` yaml
+# app/config/config*.yml
+
+faker:
     entities:
         Acme\LibraryBundle\Model\Author:
             number: 5
@@ -87,6 +93,16 @@ faker:
         Acme\LibraryBundle\Model\Book:
             custom_formatters:
                 Slug:   { method: null }
+```
+
+There are a few more optional settings available for more advanced customization of Faker:
+
+``` yaml
+faker:
+    seed:       1234
+    locale:     en_GB
+    populator:  Your\Own\Populator
+    entity:     Your\Own\EntityPopulator
 ```
 
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,7 @@
 
         <service id="faker.populator" class="%faker.populator.class%">
             <argument type="service" id="faker.generator" />
+            <argument />
         </service>
 
         <service id="faker.formatter_factory" class="Bazinga\Bundle\FakerBundle\Factory\FormatterFactory"></service>


### PR DESCRIPTION
Less configuration is needed now, both for Doctrine and Propel. Basically only `orm: doctrine` is enough.

Note that I didn't test Propel so please verify it still works, although I don't think I broke it.

Note also that it only works with the default entity manager for Doctrine. If someone else wants to fix that it'd be great.
