### PR TITLE
Changed README to work with SF2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # FakerBundle #
 
-[![Build Status](https://secure.travis-ci.org/willdurand/BazingaFakerBundle.png)](http://travis-ci.org/willdurand/BazingaFakerBundle)
-
 This bundle integrates [Faker](https://github.com/fzaninotto/Faker), a PHP library that generates fake data for you.
 It provides a command to load random data for your model objects as simple as possible.
 


### PR DESCRIPTION
The namespace register action is different on SF2.1, I've added that small change to README.
