### PR TITLE
Make FakerBundle compatible to Symfony 2.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "symfony/framework-bundle": ">=2.0,<2.4-dev",
+    "symfony/framework-bundle": "~2.0",
     "fzaninotto/faker": "~1.1"
   },
   "autoload": {


### PR DESCRIPTION
Make the FakerBundle compatible to the new awesome Symfony 2.4 version.
