### PR TITLE
Removing incorrect usage of param being passed to optional()

### DIFF
--- a/Factory/FormatterFactory.php
+++ b/Factory/FormatterFactory.php
@@ -26,7 +26,7 @@ class FormatterFactory
         return function () use ($generator, $method, $parameters, $optional) {
 
             if (null !== $optional && $generator instanceof Generator) {
-                $generator = $generator->optional((double) $optional);
+                $generator = $generator->optional();
             }
 
             return call_user_func_array(array($generator, $method), (array) $parameters);


### PR DESCRIPTION
@see docs on https://github.com/fzaninotto/Faker for correct usage of $generator->optional() ref: #34 
